### PR TITLE
* Implemented LD (u16),SP

### DIFF
--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -50,30 +50,29 @@ macro_rules! mem_set {
 macro_rules! read {
     ($cpu:expr, u16) => {
         {
-            let upper = $cpu.mmu.read_u8($cpu.registers.pc);
-            $cpu.registers.pc += 1;
             let lower = $cpu.mmu.read_u8($cpu.registers.pc);
             $cpu.registers.pc += 1;
-            m_time!($cpu, 1);
+            let upper = $cpu.mmu.read_u8($cpu.registers.pc);
+            $cpu.registers.pc += 1;
+            m_time!($cpu, 2);
             concat_u8!(upper, lower)
         }
     };
     ($cpu:expr, u8) => {
         {
             let val = $cpu.mmu.read_u8($cpu.registers.pc);
+            m_time!($cpu, 1);
             $cpu.registers.pc += 1;
             val
         }
     };
     ($cpu:expr, ($high:tt, $low:tt)) => {
         {
-            m_time!($cpu, 1);
             $cpu.mmu.read_u8(read!($cpu, $high, $low))
         }
     };
     ($cpu:expr, $high:tt, $low:tt) => {
         {
-            m_time!($cpu, 1);
             concat_u8!($cpu.registers.$high, $cpu.registers.$low)
         }
     };
@@ -85,28 +84,29 @@ macro_rules! read {
 macro_rules! write {
     ($cpu:expr, u16, $value:expr) => {
         {
-            let (upper, lower) = split_u16($value);
+            let (upper, lower) = split_u16!($value);
             let address = read!($cpu, u16);
-            $cpu.mmu.write_u8(address, low);
-            $cpu.mmu.write_u8(address + 1, high);
-            m_time!($cpu, 1);
+            $cpu.mmu.write_u8(address, lower);
+            $cpu.mmu.write_u8(address + 1, upper);
+            m_time!($cpu, 2);
         }
     };
     ($cpu:expr, ($high:tt, $low:tt), $value:expr) => {
-        $cpu.mmu.write_u8(read!($cpu, $high, $low), $value)
+        {
+            $cpu.mmu.write_u8(read!($cpu, $high, $low), $value);
+            m_time!($cpu, 1);
+        }
     };
     ($cpu:expr, $high:tt, $low:tt, $value:expr) => {
         {
             let (upper, lower) = split_u16!($value);
             $cpu.registers.$high = upper;
             $cpu.registers.$low = lower;
-            m_time!($cpu, 1);
         }
     };
     ($cpu:expr, $r:tt, $value:expr) => {
         {
             $cpu.registers.$r = $value;
-            m_time!($cpu, 1);
         }
     };
 }
@@ -114,7 +114,6 @@ macro_rules! write {
 macro_rules! nop {
     () => {
         |cpu: &mut Z80<Execute>| {
-            m_time!(cpu, 1);
         }
     }
 }
@@ -124,7 +123,6 @@ macro_rules! ld {
         |cpu: &mut Z80<Execute>| {
             let val = read!(cpu, $($source)+);
             write!(cpu, $($target)+, val);
-            m_time!(cpu, 1);
         }
     }
 }
@@ -139,6 +137,13 @@ macro_rules! inc {
             let h = (((current ^ 1) ^ new) & 0b0001_0000) << 1;
             cpu.registers.f |= z | h;
             write!(cpu, $target, new);
+        }
+    };
+    ($high:tt, $low:tt) => {
+        |cpu: &mut Z80<Execute>| {
+            let val = read!(cpu, $high, $low);
+            write!(cpu, $high, $low, val.wrapping_add(1));
+            m_time!(cpu, 1);
         }
     };
     ($($target:tt)+) => {
@@ -264,6 +269,8 @@ impl Z80<Fetch> {
                 opcode: self.mmu.read_u8(self.registers.pc),
             },
             registers: Registers {
+                m: self.registers.m + 1,
+                t: self.registers.t + 4,
                 pc: self.registers.pc + 1,
                 ..self.registers
             },
@@ -283,6 +290,7 @@ impl Z80<Decode> {
             0x05 => dec!(b),
             0x06 => ld!([b], [u8]),
             0x07 => rlca!(),
+            0x08 => ld!([u16], [sp]),
             0x17 => rla!(),
             _ => panic!("Uh, oh")
         };
@@ -391,13 +399,17 @@ mod tests {
             assert : {$($assertMacro:tt : $assertBody:tt),*}
         ) => {
             {
-                let mut cpuA = cpu_decode($opcode);
-                let mut cpuB = cpu_decode($opcode);
+                let mut fetcherA = Z80::<Fetch>::new();
+                let mut fetcherB = Z80::<Fetch>::new();
                 let function = $macro!$body;
                 $(
-                    $setupMacro!(cpuA, $setupBody);
-                    $setupMacro!(cpuB, $setupBody);
+                    $setupMacro!(fetcherA, $setupBody);
+                    $setupMacro!(fetcherB, $setupBody);
                 )*
+                fetcherA.mmu.write_u8(fetcherA.registers.pc, $opcode);
+                fetcherB.mmu.write_u8(fetcherA.registers.pc, $opcode);
+                let mut cpuA = fetcherA.fetch().decode();
+                let mut cpuB = fetcherB.fetch().decode();
                 assert_eq!(cpuA.s.instruction.opcode, $opcode);
                 (function)(&mut cpuA);
                 $(
@@ -493,8 +505,8 @@ mod tests {
         let address = concat_u8!(cpu.registers.h, cpu.registers.l);
         let value = 24 as u8;
         cpu.mmu.write_u8(address, value);
-        cpu.mmu.write_u8(0, (address >> 8) as u8);
-        cpu.mmu.write_u8(1, (address & 0xFF) as u8);
+        cpu.mmu.write_u8(0, (address & 0xFF) as u8);
+        cpu.mmu.write_u8(1, (address >> 8) as u8);
 
         // 8 bit register read
         assert_eq!(100, read!(cpu, a));
@@ -530,8 +542,8 @@ mod tests {
         let lower = 1;
         let mut cpu = cpu_execute();
         let expected_u16 = concat_u8!(upper, lower);
-        cpu.mmu.write_u8(0, upper);
-        cpu.mmu.write_u8(1, lower);
+        cpu.mmu.write_u8(0, lower);
+        cpu.mmu.write_u8(1, upper);
 
         // LD BC, u16
         ld!([b, c], [u16])(&mut cpu);
@@ -566,18 +578,18 @@ mod tests {
             ld : [ [b, c], [u16] ]
             setup : {
                 mem_set : {
-                    0 : 2,
-                    1 : 1
+                    1 : 2,
+                    2 : 1
                 }
             }
             assert : {
                 reg_eq : {
-                    b : 2,
-                    c : 1,
+                    b : 1,
+                    c : 2,
                     m : 3,
                     t : 12,
                     f : 0,
-                    pc : 2
+                    pc : 3
                 }
             }
         }
@@ -619,13 +631,13 @@ mod tests {
             setup : {
                 reg_set : {
                     b : 1,
-                    c : 1
+                    c : 2
                 }
             }
             assert : {
                 reg_eq : {
                     b : 1,
-                    c : 2,
+                    c : 3,
                     m : 2,
                     t : 8,
                     f : 0
@@ -807,15 +819,15 @@ mod tests {
             ld : [ [b], [u8] ]
             setup : {
                 mem_set : {
-                    0 : 2
+                    1 : 3
                 }
             }
             assert : {
                 reg_eq : {
                     m : 2,
                     t : 8,
-                    b : 2,
-                    pc : 1
+                    b : 3,
+                    pc : 2
                 }
             }
         }
@@ -838,6 +850,34 @@ mod tests {
                     t : 4,
                     a : 0x2B,
                     f : 0b0001_0000
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn ld_u16_sp_indirect() {
+        assert_instruction! {
+            opcode : 0x08
+            ld : [ [u16], [sp] ]
+            setup : {
+                reg_set : {
+                    sp : 0b1000_1000_0100_0100
+                },
+                mem_set : {
+                    1 : 0b0001_0001,
+                    2 : 0b0010_0010
+                }
+            }
+            assert : {
+                reg_eq : {
+                    m : 5,
+                    t : 20,
+                    pc : 3
+                },
+                mem_eq : {
+                    (0b0010_0010, 0b0001_0001) : 0b0100_0100,
+                    (0b0010_0010, 0b0001_0010) : 0b1000_1000
                 }
             }
         }


### PR DESCRIPTION
* Fixed endianness bug in high/low byte order when writing u16 values to two u8 mmu values
* Adjusted timing to match the instruction specifications (where fetch consumes 1 m-time)
Closes #16